### PR TITLE
Add price diff view

### DIFF
--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -1,3 +1,9 @@
+<style>
+  .fullprice {
+      text-decoration: line-through;
+  }
+</style>
+
 <h2>My Cart</h2>
 <% if cart.items.empty? %>
   <p>Your Cart is Empty!</p>
@@ -8,7 +14,8 @@
       <h2><%= link_to item.name, "/items/#{item.id}" %></h2>
       <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw">
       <% if item.merchant.discount? && cart.items_needed_for_discount?(item.id) %>
-        <p>Price: <%= number_to_currency(item.apply_discount(cart.count_of(item.id))) %></p>
+        <p>New Discounted Price: <%= number_to_currency(item.apply_discount(cart.count_of(item.id))) %></p>
+        <p class="fullprice">Price: <%= number_to_currency(item.price) %></p>
         <p>Subtotal: <%= number_to_currency(cart.discounted_subtotal_of(item.id)) %></p>
       <% else %>
         <p>Price: <%= number_to_currency(item.price) %></p>

--- a/spec/features/cart/add_discount_spec.rb
+++ b/spec/features/cart/add_discount_spec.rb
@@ -112,6 +112,25 @@ RSpec.describe 'Add Discount to Items' do
           expect(page).to have_content("Subtotal: $3.00")
         end
       end
+
+      it "shows price before discount striked out so visitor can see difference in discount price" do
+        visit item_path(@ogre)
+        click_button 'Add to Cart'
+
+        visit '/cart'
+
+        within "#item-#{@ogre.id}" do
+          4.times do click_button('More of This!')
+          end
+        end
+
+        within "#item-#{@ogre.id}" do
+          expect(page).to have_content("New Discounted Price: $19.00")
+          within  ".fullprice" do
+            expect(page).to have_content("Price: $20.00")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/features/user/orders/create_spec.rb
+++ b/spec/features/user/orders/create_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe 'Create Order' do
       @brian = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
       @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 54 )
       @giant = @megan.items.create!(name: 'Giant', description: "I'm a Giant!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 20 )
+      @donut = @megan.items.create!(name: 'Donut', description: "I'm a circle!", price: 5, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 24 )
       @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 19 )
       @user = User.create!(name: 'Megan', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, email: 'megan@example.com', password: 'securepassword')
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
@@ -93,6 +94,8 @@ RSpec.describe 'Create Order' do
       visit item_path(@hippo)
       click_button 'Add to Cart'
       visit item_path(@giant)
+      click_button 'Add to Cart'
+      visit item_path(@donut)
       click_button 'Add to Cart'
 
       visit '/cart'
@@ -114,7 +117,7 @@ RSpec.describe 'Create Order' do
       expect(current_path).to eq('/profile/orders')
 
       within "#order-#{order.id}" do
-        expect(page).to have_content("Total: $595.00")
+        expect(page).to have_content("Total: $600.00")
       end
     end
   end


### PR DESCRIPTION
This PR will:
- Improve test coverage by adding an item with no discount to the order in test
- Add view of original price striked out when a discount is applied
- All tests passing